### PR TITLE
Fix NullReferenceException when [HideIf] compares a field's value with null when the field's value is actually null

### DIFF
--- a/Assets/MarkupAttributes/Core/Editor/ConditionWrapper.cs
+++ b/Assets/MarkupAttributes/Core/Editor/ConditionWrapper.cs
@@ -156,7 +156,7 @@ namespace MarkupAttributes.Editor
         private bool FromMemberValue(object value)
         {
             if (hasMemberValue)
-                return value.Equals(memberValue) ^ inverted;
+                return object.Equals(value, memberValue) ^ inverted;
             else
                 return (bool)value ^ inverted;
         }


### PR DESCRIPTION
I encountered this bug when both `value` and `memberValue` were null. This is the fix I made.