### PR TITLE
Match material property size with Unity's defaults

### DIFF
--- a/Assets/MarkupAttributes/Core/Editor/MarkedUpShaderGUI.cs
+++ b/Assets/MarkupAttributes/Core/Editor/MarkedUpShaderGUI.cs
@@ -55,6 +55,12 @@ namespace MarkupAttributes.Editor
                 }
             }
             layoutController.Finish();
+
+            if (UnityEngine.Rendering.SupportedRenderingFeatures.active.editableMaterialRenderQueue) {
+                materialEditor.RenderQueueField();
+            }
+            materialEditor.EnableInstancingField();
+            materialEditor.DoubleSidedGIField();
         }
 
         private void Initialize(MaterialEditor materialEditor, MaterialProperty[] properties)

--- a/Assets/MarkupAttributes/Core/Editor/MarkedUpShaderGUI.cs
+++ b/Assets/MarkupAttributes/Core/Editor/MarkedUpShaderGUI.cs
@@ -28,6 +28,8 @@ namespace MarkupAttributes.Editor
         {
             Initialize(materialEditor, properties);
 
+            materialEditor.SetDefaultGUIWidths();
+            
             layoutController.Begin();
             for (int i = 0; i < properties.Length; i++)
             {


### PR DESCRIPTION
I wanted the material gui to render the labels, controls and everything the same way the default one does. Searching around with ILSpy to see how they do it I found that, fortunately, it was done with a single line.

This is how it looks before and after the change:

Before             | After
:-------------------------:|:-------------------------:
![1657254525 2253](https://user-images.githubusercontent.com/5580666/177917037-933df842-4386-46a0-83cd-e5d90f8eca4d.png)  |  ![1657254470 2252](https://user-images.githubusercontent.com/5580666/177916960-c3ccb7ad-42b6-4105-a422-2a565cfcfd7c.png)



